### PR TITLE
TAG-342 Ikke ha alle config-verdier som miljøvariabler i yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ Kjør container
 Hvis localhost ikke fungerer, prøv med IP-en du finner med følgende kommando:
 
 `docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' container_name_or_id`
+
+### Feature toggling
+Toggle av/på GSAK-innsending ved å apply-e appen med 
+```
+    - name: ENABLE_GSAK
+      value: "true"
+```
+i ønsket riktig miljø.

--- a/preprod-nais.yaml
+++ b/preprod-nais.yaml
@@ -21,10 +21,6 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: preprod
-    - name: GSAK_URL
-      value: https://oppgave.nais.preprod.local/api/v1/oppgaver
-    - name: NORG_URL
-      value: https://app-q0.adeo.no/norg2/api/v1
     - name: ENABLE_GSAK
       value: "true"
   prometheus:

--- a/prod-nais.yaml
+++ b/prod-nais.yaml
@@ -21,10 +21,6 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod
-    - name: GSAK_URL
-      value: https://oppgave.nais.adeo.no/api/v1/oppgaver
-    - name: NORG_URL
-      value: https://app.adeo.no/norg2/api/v1
     - name: ENABLE_GSAK
       value: "true"
   prometheus:

--- a/src/main/java/no/nav/tag/kontakt/oss/fylkesinndelingMedNavEnheter/integrasjon/NorgKlient.java
+++ b/src/main/java/no/nav/tag/kontakt/oss/fylkesinndelingMedNavEnheter/integrasjon/NorgKlient.java
@@ -8,6 +8,7 @@ import no.nav.tag.kontakt.oss.KontaktskjemaException;
 import no.nav.tag.kontakt.oss.fylkesinndelingMedNavEnheter.KommuneEllerBydel;
 import no.nav.tag.kontakt.oss.fylkesinndelingMedNavEnheter.NavEnhet;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.*;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,7 @@ public class NorgKlient {
 
     public NorgKlient(
             RestTemplate restTemplate,
-            @Value("${NORG_URL:default}") String norgUrl
+            @Value("${norg.url}") String norgUrl
     ) {
         restTemplate.setErrorHandler(new RestTemplateErrorHandler());
         this.restTemplate = restTemplate;

--- a/src/main/java/no/nav/tag/kontakt/oss/gsak/integrasjon/GsakKlient.java
+++ b/src/main/java/no/nav/tag/kontakt/oss/gsak/integrasjon/GsakKlient.java
@@ -27,7 +27,7 @@ public class GsakKlient {
     @Autowired
     public GsakKlient(
             RestTemplate restTemplate,
-            @Value("${GSAK_URL:default}") String gsakUrl
+            @Value("${gsak.url}") String gsakUrl
     ) {
         this.restTemplate = restTemplate;
         this.gsakUrl = gsakUrl;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,12 +1,29 @@
-spring:
-  h2.console:
-    enabled: false
-    path: /h2
-
 controller.basepath: ${CONTROLLER_BASEPATH:/kontakt-oss-api}
 
 management.endpoints.web:
   exposure.include: info, health, metrics, prometheus
   base-path: ${CONTROLLER_BASEPATH:/kontakt-oss-api}/internal/actuator
 
+---
+spring:
+  profiles: dev
+  h2.console:
+    enabled: true
+    path: /h2
+
+gsak.url: ""
+norg.url: ""
+
 ENABLE_GSAK: true
+
+---
+spring:
+  profiles: preprod
+gsak.url: https://oppgave.nais.preprod.local/api/v1/oppgaver
+norg.url: https://app-q0.adeo.no/norg2/api/v1
+
+---
+spring:
+  profiles: prod
+gsak.url: https://oppgave.nais.adeo.no/api/v1/oppgaver
+norg.url: https://app.adeo.no/norg2/api/v1


### PR DESCRIPTION
Dette er "penere", og gjør mockingen lettere i senere PR