### PR TITLE
Tweak HikariCP pool size

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,8 @@ spring:
   datasource:
     hikari:
       max-lifetime: 300000 # 5 minutter
+      maximum-pool-size: 5
+      minimum-idle: 1
 gsak.url: https://oppgave.nais.preprod.local/api/v1/oppgaver
 norg.url: https://app-q0.adeo.no/norg2/api/v1
 kodeverk.url: https://kodeverk.nais.preprod.local/api/v1
@@ -42,6 +44,8 @@ spring:
   datasource:
     hikari:
       max-lifetime: 300000 # 5 minutter
+      maximum-pool-size: 5
+      minimum-idle: 1
 gsak.url: https://oppgave.nais.adeo.no/api/v1/oppgaver
 norg.url: https://app.adeo.no/norg2/api/v1
 kodeverk.url: https://kodeverk.nais.adeo.no/api/v1


### PR DESCRIPTION
Max size = 5 connections.
Min idle = 1 connection: reduces load
on the database due to unused idle
connections.