### PR TITLE
KAIZEN-0: Logger mer informasjon i gsakOppgaveSendt

### DIFF
--- a/src/main/java/no/nav/tag/kontakt/oss/events/GsakOppgaveSendt.java
+++ b/src/main/java/no/nav/tag/kontakt/oss/events/GsakOppgaveSendt.java
@@ -1,8 +1,11 @@
 package no.nav.tag.kontakt.oss.events;
 
 import lombok.Value;
+import no.nav.tag.kontakt.oss.gsak.GsakOppgaveService.Behandlingsresultat;
+import no.nav.tag.kontakt.oss.gsak.integrasjon.GsakRequest;
 
 @Value
 public class GsakOppgaveSendt {
-    private final boolean suksess;
+    private final Behandlingsresultat behandlingsresultat;
+    private final GsakRequest gsakRequest;
 }

--- a/src/main/java/no/nav/tag/kontakt/oss/gsak/integrasjon/GsakRequest.java
+++ b/src/main/java/no/nav/tag/kontakt/oss/gsak/integrasjon/GsakRequest.java
@@ -1,12 +1,14 @@
 package no.nav.tag.kontakt.oss.gsak.integrasjon;
 
-import lombok.Value;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
-@Value
+@Data
+@AllArgsConstructor
 public class GsakRequest {
     private final String tildeltEnhetsnr;
     private final String opprettetAvEnhetsnr;
-    private final String orgnr;
+    private String orgnr;
     private final String beskrivelse;
     private final String temagruppe;
     private final String tema;
@@ -14,4 +16,5 @@ public class GsakRequest {
     private final String prioritet;
     private final String aktivDato;
     private final String fristFerdigstillelse;
+
 }

--- a/src/main/java/no/nav/tag/kontakt/oss/metrics/MetricsListeners.java
+++ b/src/main/java/no/nav/tag/kontakt/oss/metrics/MetricsListeners.java
@@ -9,6 +9,9 @@ import no.nav.tag.kontakt.oss.gsak.GsakOppgave.OppgaveStatus;
 import no.nav.tag.kontakt.oss.gsak.GsakOppgaveService.Behandlingsresultat;
 
 import no.nav.tag.kontakt.oss.gsak.integrasjon.GsakRequest;
+
+import java.util.Optional;
+
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -37,13 +40,13 @@ public class MetricsListeners {
     @EventListener
     public void gsakOppgaveSendt(GsakOppgaveSendt event) {
         Behandlingsresultat resultat = event.getBehandlingsresultat();
-        GsakRequest gsakRequest = event.getGsakRequest();
+        Optional<GsakRequest> gsakRequest = Optional.ofNullable(event.getGsakRequest());
         log.info(
                 "event=gsakoppgave.sendt, success={}, gsakId={}, orgnr={}, tildeltEnhetsnr={}",
                 OppgaveStatus.FEILET != resultat.getStatus(),
                 resultat.getGsakId(),
-                gsakRequest.getOrgnr(),
-                gsakRequest.getTildeltEnhetsnr()
+                gsakRequest.isEmpty() ? null : gsakRequest.get().getOrgnr(),
+                gsakRequest.isEmpty() ? null : gsakRequest.get().getTildeltEnhetsnr()
         );
     }
 

--- a/src/main/java/no/nav/tag/kontakt/oss/metrics/MetricsListeners.java
+++ b/src/main/java/no/nav/tag/kontakt/oss/metrics/MetricsListeners.java
@@ -5,6 +5,9 @@ import no.nav.tag.kontakt.oss.Kontaktskjema;
 import no.nav.tag.kontakt.oss.events.BesvarelseMottatt;
 import no.nav.tag.kontakt.oss.events.FylkesinndelingOppdatert;
 import no.nav.tag.kontakt.oss.events.GsakOppgaveSendt;
+import no.nav.tag.kontakt.oss.gsak.GsakOppgave.OppgaveStatus;
+import no.nav.tag.kontakt.oss.gsak.GsakOppgaveService.Behandlingsresultat;
+
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -33,7 +36,8 @@ public class MetricsListeners {
 
     @EventListener
     public void gsakOppgaveSendt(GsakOppgaveSendt event) {
-        log.info("event=gsakoppgave.sendt, success={},", event.isSuksess());
+        Behandlingsresultat resultat = event.getBehandlingsresultat();
+        log.info("event=gsakoppgave.sendt, success={}, gsakId={}, gsakRequest={},", OppgaveStatus.FEILET != resultat.getStatus(), resultat.getGsakId(), event.getGsakRequest());
     }
 
     @EventListener

--- a/src/main/java/no/nav/tag/kontakt/oss/metrics/MetricsListeners.java
+++ b/src/main/java/no/nav/tag/kontakt/oss/metrics/MetricsListeners.java
@@ -8,6 +8,7 @@ import no.nav.tag.kontakt.oss.events.GsakOppgaveSendt;
 import no.nav.tag.kontakt.oss.gsak.GsakOppgave.OppgaveStatus;
 import no.nav.tag.kontakt.oss.gsak.GsakOppgaveService.Behandlingsresultat;
 
+import no.nav.tag.kontakt.oss.gsak.integrasjon.GsakRequest;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -21,8 +22,7 @@ public class MetricsListeners {
 
         // Setter komma til slutt for å skille mellom verdier som starter likt,
         // f.eks. REKRUTTERING og REKRUTTERING_MED_TILRETTELEGGING.
-        log.info(
-                "event=kontaktskjema.mottatt"
+        log.info("event=kontaktskjema.mottatt"
                 + ",success=" + event.isSuksess()
                 + ",fylke=" + kontaktskjema.getFylke()
                 + ",kommunenr=" + kontaktskjema.getKommunenr()
@@ -37,7 +37,14 @@ public class MetricsListeners {
     @EventListener
     public void gsakOppgaveSendt(GsakOppgaveSendt event) {
         Behandlingsresultat resultat = event.getBehandlingsresultat();
-        log.info("event=gsakoppgave.sendt, success={}, gsakId={}, gsakRequest={},", OppgaveStatus.FEILET != resultat.getStatus(), resultat.getGsakId(), event.getGsakRequest());
+        GsakRequest gsakRequest = event.getGsakRequest();
+        log.info(
+                "event=gsakoppgave.sendt, success={}, gsakId={}, orgnr={}, tildeltEnhetsnr={}",
+                OppgaveStatus.FEILET != resultat.getStatus(),
+                resultat.getGsakId(),
+                gsakRequest.getOrgnr(),
+                gsakRequest.getTildeltEnhetsnr()
+        );
     }
 
     @EventListener

--- a/src/test/java/no/nav/tag/kontakt/oss/gsak/GsakOppgaveServiceTest.java
+++ b/src/test/java/no/nav/tag/kontakt/oss/gsak/GsakOppgaveServiceTest.java
@@ -101,7 +101,7 @@ public class GsakOppgaveServiceTest {
         when(gsakKlient.opprettGsakOppgave(any())).thenReturn(gsakId);
         gsakOppgaveService.opprettOppgaveOgLagreStatus(kontaktskjema);
 
-        verify(eventPublisher, times(1)).publishEvent(eq(new GsakOppgaveOpprettet(gsakId, kontaktskjema)));
+        verify(eventPublisher, times(1)).publishEvent(new GsakOppgaveOpprettet(gsakId, kontaktskjema));
     }
 
     @Test

--- a/src/test/java/no/nav/tag/kontakt/oss/gsak/GsakOppgaveServiceTest.java
+++ b/src/test/java/no/nav/tag/kontakt/oss/gsak/GsakOppgaveServiceTest.java
@@ -11,6 +11,7 @@ import no.nav.tag.kontakt.oss.BadRequestException;
 import no.nav.tag.kontakt.oss.gsak.integrasjon.GsakKlient;
 import no.nav.tag.kontakt.oss.gsak.integrasjon.GsakRequest;
 import no.nav.tag.kontakt.oss.navenhetsmapping.NavEnhetService;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,15 +19,18 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.MDC;
 import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDateTime;
 
 import static no.nav.tag.kontakt.oss.testUtils.TestData.kontaktskjema;
 import static no.nav.tag.kontakt.oss.testUtils.TestData.kontaktskjemaBuilder;
+import static no.nav.tag.kontakt.oss.gsak.GsakOppgave.OppgaveStatus.FEILET;
 import static no.nav.tag.kontakt.oss.gsak.GsakOppgave.OppgaveStatus.OK;
 import static no.nav.tag.kontakt.oss.gsak.GsakOppgaveService.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -83,7 +87,11 @@ public class GsakOppgaveServiceTest {
     @Test
     public void skalPublisereGsakOppgaveSendtOmVellykketInnsending() {
         gsakOppgaveService.opprettOppgaveOgLagreStatus(kontaktskjema());
-        verify(eventPublisher, times(1)).publishEvent(new GsakOppgaveSendt(true));
+    
+        ArgumentCaptor<GsakOppgaveSendt> argumentCaptor = forClass(GsakOppgaveSendt.class);
+        //Det publiseres to eventer med ulike argumenter, derfor times(2) selv om vi bare er interessert i den siste.
+        verify(eventPublisher, times(2)).publishEvent(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getBehandlingsresultat().getStatus()).isEqualTo(OK);
     }
 
     @Test
@@ -92,7 +100,8 @@ public class GsakOppgaveServiceTest {
         Integer gsakId = 1;
         when(gsakKlient.opprettGsakOppgave(any())).thenReturn(gsakId);
         gsakOppgaveService.opprettOppgaveOgLagreStatus(kontaktskjema);
-        verify(eventPublisher, times(1)).publishEvent(new GsakOppgaveOpprettet(gsakId, kontaktskjema));
+
+        verify(eventPublisher, times(1)).publishEvent(eq(new GsakOppgaveOpprettet(gsakId, kontaktskjema)));
     }
 
     @Test
@@ -100,7 +109,10 @@ public class GsakOppgaveServiceTest {
         when(gsakKlient.opprettGsakOppgave(any())).thenThrow(KontaktskjemaException.class);
 
         gsakOppgaveService.opprettOppgaveOgLagreStatus(kontaktskjema());
-        verify(eventPublisher, times(1)).publishEvent(new GsakOppgaveSendt(false));
+        
+        ArgumentCaptor<GsakOppgaveSendt> argumentCaptor = forClass(GsakOppgaveSendt.class);
+        verify(eventPublisher, times(1)).publishEvent(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getBehandlingsresultat().getStatus()).isEqualTo(FEILET);
     }
 
     @Test
@@ -130,11 +142,8 @@ public class GsakOppgaveServiceTest {
         when(gsakKlient.opprettGsakOppgave(any()))
                 .thenThrow(BadRequestException.class)
                 .thenThrow(BadRequestException.class);
-        try {
-            gsakOppgaveService.opprettOppgaveOgLagreStatus(kontaktskjema());
-        } catch (KontaktskjemaException e) {
-            verify(gsakKlient, times(2)).opprettGsakOppgave(any());
-        }
+        gsakOppgaveService.opprettOppgaveOgLagreStatus(kontaktskjema());
+        verify(gsakKlient, times(2)).opprettGsakOppgave(any());
     }
 
     @Test
@@ -190,5 +199,23 @@ public class GsakOppgaveServiceTest {
     private GsakRequest capturedGsakRequest() {
         verify(gsakKlient, times(1)).opprettGsakOppgave(gsakRequestArgumentCaptor.capture());
         return gsakRequestArgumentCaptor.getValue();
+    }
+    
+    @Test
+    public void skal_fjerne_correlationId() {
+        gsakOppgaveService.opprettOppgaveOgLagreStatus(kontaktskjema());
+
+        assertThat(MDC.get(CORRELATION_ID)).isNull();
+    }
+    
+    @Test
+    public void skal_fjerne_correlationId_ved_exception() {
+        doThrow(RuntimeException.class).when(oppgaveRepository).save(any());
+        try {
+            gsakOppgaveService.opprettOppgaveOgLagreStatus(kontaktskjema());
+        } catch (Exception e) {
+        }
+
+        assertThat(MDC.get(CORRELATION_ID)).isNull();
     }
 }

--- a/src/test/java/no/nav/tag/kontakt/oss/metrics/MetricsListenersTest.java
+++ b/src/test/java/no/nav/tag/kontakt/oss/metrics/MetricsListenersTest.java
@@ -1,0 +1,20 @@
+package no.nav.tag.kontakt.oss.metrics;
+
+import org.junit.Test;
+
+import no.nav.tag.kontakt.oss.events.GsakOppgaveSendt;
+import no.nav.tag.kontakt.oss.gsak.GsakOppgave.OppgaveStatus;
+import no.nav.tag.kontakt.oss.gsak.GsakOppgaveService;
+import no.nav.tag.kontakt.oss.testUtils.TestData;
+
+public class MetricsListenersTest {
+
+    @Test    
+    public void testGsakOppgaveSendt() {
+        //Svært enkel test for å kunne observere hvordan logglinjen vil se ut, og for å verifisere at enkelte data kan være null
+        new MetricsListeners().gsakOppgaveSendt(new GsakOppgaveSendt(new GsakOppgaveService.Behandlingsresultat(OppgaveStatus.OK, 1), null));
+        new MetricsListeners().gsakOppgaveSendt(new GsakOppgaveSendt(new GsakOppgaveService.Behandlingsresultat(OppgaveStatus.FEILET, null), null));
+        new MetricsListeners().gsakOppgaveSendt(new GsakOppgaveSendt(new GsakOppgaveService.Behandlingsresultat(OppgaveStatus.DISABLED, null), null));
+        new MetricsListeners().gsakOppgaveSendt(new GsakOppgaveSendt(new GsakOppgaveService.Behandlingsresultat(OppgaveStatus.OK, 1), TestData.gsakRequest()));
+    }
+}


### PR DESCRIPTION
Legger på noe mer informasjon i logg-linjen som lages i `MetricsListeners.gsakOppgaveSendt()`. Da blir det lettere å se hvilken informasjon som sendes til gsak og å se sammenhengen mellom gsakoppgave og kontaktskjema uten å måtte gjøre databasespørringer.
Har også gjort en del endringer i GsakOppgaveService som følge av dette, samt fikset en potensiell bug som ikke blanket ut correlationId dersom noe feiler.