### PR TITLE
Bruk LegacyCookieProcessor for å ikke logge cookies

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/kontakt/oss/config/TomcatConfig.java
+++ b/src/main/java/no/nav/arbeidsgiver/kontakt/oss/config/TomcatConfig.java
@@ -1,0 +1,24 @@
+package no.nav.arbeidsgiver.kontakt.oss.config;
+
+import org.apache.tomcat.util.http.LegacyCookieProcessor;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// Tomcat logger feilformaterte cookies by default. Dette er et sikkerhetshull.
+// Her fikser vi dette ved å bruke LegacyCookieProcessor, som ikke logger slike.
+// Se https://www.jvt.me/posts/2020/04/07/tomcat-cookie-disclosure/ for mer informasjon.
+@Configuration
+public class TomcatConfig {
+    @Bean
+    WebServerFactoryCustomizer<TomcatServletWebServerFactory> cookieProcessorCustomizer() {
+        return new WebServerFactoryCustomizer<>() {
+            @Override
+            public void customize(TomcatServletWebServerFactory tomcatServletWebServerFactory) {
+                tomcatServletWebServerFactory
+                        .addContextCustomizers(context -> context.setCookieProcessor(new LegacyCookieProcessor()));
+            }
+        };
+    }
+}


### PR DESCRIPTION
Kan testes ved å kjøre:
`curl --cookie "userId=wibble,this=logged" http://localhost:8080/kontakt-oss-api/internal/healthcheck`
Uten ny config vil det logges "A cookie header was received ..."

ref:
https://nav-it.slack.com/archives/C6UBU9EAU/p1599140965016100
https://www.jvt.me/posts/2020/04/07/tomcat-cookie-disclosure/