### PR TITLE
Oppdater avhengigheter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.4.6</version>
+            <version>1.4.8</version>
         </dependency>
 
         <!-- Shedlock -->
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.8.0</version>
         </dependency>
 
         <!-- JSON-logging -->
@@ -121,13 +121,13 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.5.3</version>
+            <version>1.5.5</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.27.1</version>
+            <version>2.27.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Spring Boot har kommet med en ny "milepælsversjon" 2.4.0-M3, men jeg tenker vi kan vente med å oppgradere til neste RELEASE-versjon.