### PR TITLE
Oppgrader avhengigheter desember 2020

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.5.RELEASE</version>
+        <version>2.4.0</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,19 +85,19 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.4.8</version>
+            <version>1.5.0</version>
         </dependency>
 
         <!-- Shedlock -->
         <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-spring</artifactId>
-            <version>4.15.1</version>
+            <version>4.17.0</version>
         </dependency>
         <dependency>
             <groupId>net.javacrumbs.shedlock</groupId>
             <artifactId>shedlock-provider-jdbc-template</artifactId>
-            <version>4.15.1</version>
+            <version>4.17.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -109,19 +109,19 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>6.4</version>
+            <version>6.5</version>
         </dependency>
 
         <dependency>
             <groupId>no.bekk.bekkopen</groupId>
             <artifactId>nocommons</artifactId>
-            <version>0.10.0</version>
+            <version>0.11.0</version>
         </dependency>
 
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.5.5</version>
+            <version>1.6.1</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/ApiTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/ApiTest.java
@@ -3,14 +3,12 @@ package no.nav.arbeidsgiver.kontakt.oss;
 import lombok.SneakyThrows;
 import no.nav.arbeidsgiver.kontakt.oss.testUtils.DatabasePopulator;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -20,11 +18,8 @@ import java.net.http.HttpResponse;
 
 import static java.net.http.HttpClient.newBuilder;
 import static java.net.http.HttpResponse.BodyHandlers.ofString;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class ApiTest {
 
@@ -43,7 +38,7 @@ public class ApiTest {
         );
     }
 
-    @Before
+    @BeforeEach
     @SneakyThrows
     public void populerDatabase() {
         databasePopulator.populerFylkesinndelingRepositoryForÅUnngåNullpointers();
@@ -52,8 +47,8 @@ public class ApiTest {
     @Test
     public void postKontaktskjema_OK() throws Exception {
         HttpResponse<?> response = newBuilder().build().send(createRequest(OK_KONTAKTSKJEMA_JSON), ofString());
-        assertThat(response.statusCode(), is(200));
-        assertThat(response.body(), is("\"OK\""));
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("\"OK\"");
     }
 
     private HttpRequest createRequest(String body) {
@@ -74,7 +69,7 @@ public class ApiTest {
         String bodyMedForLangtKommunenr = OK_KONTAKTSKJEMA_JSON.replaceFirst("1841", "1084109");
 
         HttpResponse<?> response = HttpClient.newBuilder().build().send(createRequest(bodyMedForLangtKommunenr), ofString());
-        assertThat(response.statusCode(), is(400));
+        assertThat(response.statusCode()).isEqualTo(400);
     }
 
 }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/KafkaTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/KafkaTest.java
@@ -9,51 +9,53 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDateTime;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
+@DirtiesContext
 @ActiveProfiles({"kafka-test", "local"})
 @TestPropertySource(properties = {"mock.enabled=false"})
-@DirtiesContext
+@EmbeddedKafka(
+        controlledShutdown = true,
+        partitions = 1,
+        topics = {KontaktskjemaMottattProducer.TOPIC}
+)
 public class KafkaTest {
 
     @Autowired
     private ApplicationEventPublisher eventPublisher;
 
-    @ClassRule
-    public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, true, 1, KontaktskjemaMottattProducer.TOPIC);
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
 
     private Consumer<String, String> consumer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "true", embeddedKafka.getEmbeddedKafka());
+        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "true", embeddedKafkaBroker);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 
         ConsumerFactory<String, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
         consumer = cf.createConsumer();
-        embeddedKafka.getEmbeddedKafka().consumeFromAnEmbeddedTopic(consumer, KontaktskjemaMottattProducer.TOPIC);
+        embeddedKafkaBroker.consumeFromAnEmbeddedTopic(consumer, KontaktskjemaMottattProducer.TOPIC);
     }
 
     @Test

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/KontaktskjemaApplicationTests.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/KontaktskjemaApplicationTests.java
@@ -1,12 +1,9 @@
 package no.nav.arbeidsgiver.kontakt.oss;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {"mock.enabled=false"})
 public class KontaktskjemaApplicationTests {

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/KontaktskjemaControllerTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/KontaktskjemaControllerTest.java
@@ -1,19 +1,18 @@
 package no.nav.arbeidsgiver.kontakt.oss;
 
 import no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class KontaktskjemaControllerTest {
 
     @Mock
@@ -21,7 +20,7 @@ public class KontaktskjemaControllerTest {
 
     private KontaktskjemaController kontaktskjemaController;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         kontaktskjemaController = new KontaktskjemaController(kontaktskjemaService);
     }
@@ -36,12 +35,12 @@ public class KontaktskjemaControllerTest {
     @Test
     public void meldInteresse__skal_returnere_429_ved_for_mange_innsendinger() {
         when(kontaktskjemaService.harMottattForMangeInnsendinger()).thenReturn(true);
-        assertThat(kontaktskjemaController.meldInteresse(TestData.kontaktskjema()).getStatusCode(), is(HttpStatus.TOO_MANY_REQUESTS));
+        assertThat(kontaktskjemaController.meldInteresse(TestData.kontaktskjema()).getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
     }
 
     @Test
     public void meldInteresse__skal_returnere_200_dersom_OK() {
-        assertThat(kontaktskjemaController.meldInteresse(TestData.kontaktskjema()).getStatusCode(), is(HttpStatus.OK));
+        assertThat(kontaktskjemaController.meldInteresse(TestData.kontaktskjema()).getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
 }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/KontaktskjemaRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/KontaktskjemaRepositoryTest.java
@@ -5,22 +5,19 @@ import no.nav.arbeidsgiver.kontakt.oss.gsak.GsakOppgaveRepository;
 import no.nav.arbeidsgiver.kontakt.oss.salesforce.utsending.KontaktskjemaUtsending;
 import no.nav.arbeidsgiver.kontakt.oss.salesforce.utsending.KontaktskjemaUtsendingRepository;
 import no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.relational.core.conversion.DbActionExecutionException;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDateTime;
 
 import static java.time.LocalDateTime.now;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {"mock.enabled=false"})
 public class KontaktskjemaRepositoryTest {
@@ -34,7 +31,7 @@ public class KontaktskjemaRepositoryTest {
     @Autowired
     private GsakOppgaveRepository oppgaveRepository;
 
-    @After
+    @AfterEach
     public void tearDown() {
         kontaktskjemaRepository.deleteAll();
         oppgaveRepository.deleteAll();
@@ -49,14 +46,14 @@ public class KontaktskjemaRepositoryTest {
     public void skalLagreOgHenteUt() {
         Kontaktskjema lagretSkjema = kontaktskjemaRepository.save(TestData.kontaktskjema());
 
-        assertThat(kontaktskjemaRepository.findById(lagretSkjema.getId()).isPresent(), is(true));
+        assertThat(kontaktskjemaRepository.findById(lagretSkjema.getId())).isPresent();
     }
 
-    @Test(expected = DbActionExecutionException.class)
+    @Test
     public void skalFeileHvisKommuneErForLang() {
         Kontaktskjema kontaktskjema = TestData.kontaktskjema();
         kontaktskjema.setKommunenr("1234567");
-        kontaktskjemaRepository.save(kontaktskjema);
+        assertThrows(DbActionExecutionException.class, () -> kontaktskjemaRepository.save(kontaktskjema));
     }
 
     @Test
@@ -71,9 +68,10 @@ public class KontaktskjemaRepositoryTest {
         kontaktskjemaRepository.save(skjemaMedDato(now().minusDays(3)));
         kontaktskjemaRepository.save(skjemaMedDato(now().minusDays(1)));
 
-        assertThat(kontaktskjemaRepository.findAllNewerThan(now().minusDays(4)).size(), is(2));
-        assertThat(kontaktskjemaRepository.findAllNewerThan(now().minusDays(2)).size(), is(1));
-        assertThat(kontaktskjemaRepository.findAllNewerThan(now()).size(), is(0));
+        assertThat(kontaktskjemaRepository.findAllNewerThan(now().minusDays(4)).size()).isEqualTo(2);
+
+        assertThat(kontaktskjemaRepository.findAllNewerThan(now().minusDays(2)).size()).isEqualTo(1);
+        assertThat(kontaktskjemaRepository.findAllNewerThan(now()).size()).isEqualTo(0);
     }
 
     private Kontaktskjema skjemaMedDato(LocalDateTime opprettetTidspunkt) {
@@ -85,25 +83,25 @@ public class KontaktskjemaRepositoryTest {
     @Test
     public void skalHenteSkjemaSomIkkeHarGsakOppgave() {
         kontaktskjemaRepository.save(TestData.kontaktskjema());
-        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size(), is(1));
+        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size()).isEqualTo(1);
     }
 
     @Test
     public void skalIkkeHenteSkjemaDersomGsakOppgaveErOpprettet() {
         Kontaktskjema lagretSkjema = kontaktskjemaRepository.save(TestData.kontaktskjema());
-        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size(), is(1));
+        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size()).isEqualTo(1);
         oppgaveRepository.save(GsakOppgave.builder().kontaktskjemaId(lagretSkjema.getId()).status(GsakOppgave.OppgaveStatus.OK).build());
-        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size(), is(0));
+        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size()).isEqualTo(0);
     }
 
     @Test
     public void skalHenteSkjemaDersomGsakOppgaveHarFeilet() {
         Kontaktskjema lagretSkjema = kontaktskjemaRepository.save(TestData.kontaktskjema());
-        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size(), is(1));
+        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size()).isEqualTo(1);
         oppgaveRepository.save(GsakOppgave.builder().kontaktskjemaId(lagretSkjema.getId()).status(GsakOppgave.OppgaveStatus.FEILET).build());
-        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size(), is(1));
+        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size()).isEqualTo(1);
         oppgaveRepository.save(GsakOppgave.builder().kontaktskjemaId(lagretSkjema.getId()).status(GsakOppgave.OppgaveStatus.OK).build());
-        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size(), is(0));
+        assertThat(kontaktskjemaRepository.findAllWithNoGsakOppgave().size()).isEqualTo(0);
     }
 
     @Test
@@ -117,7 +115,7 @@ public class KontaktskjemaRepositoryTest {
                 )
         );
 
-        assertThat(kontaktskjemaRepository.hentKontakskjemaerSomSkalSendesTilSalesforce().size(), is(0));
+        assertThat(kontaktskjemaRepository.hentKontakskjemaerSomSkalSendesTilSalesforce().size()).isEqualTo(0);
     }
 
     @Test
@@ -125,7 +123,7 @@ public class KontaktskjemaRepositoryTest {
         Kontaktskjema lagretSkjema = kontaktskjemaRepository.save(TestData.kontaktskjema());
         kontaktskjemaUtsendingRepository.save(KontaktskjemaUtsending.klarTilUtsending(lagretSkjema.getId(), now()));
 
-        assertThat(kontaktskjemaRepository.hentKontakskjemaerSomSkalSendesTilSalesforce().size(), is(1));
+        assertThat(kontaktskjemaRepository.hentKontakskjemaerSomSkalSendesTilSalesforce().size()).isEqualTo(1);
     }
 
 }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/ShedlockTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/ShedlockTest.java
@@ -6,8 +6,8 @@ import net.javacrumbs.shedlock.core.LockConfiguration;
 import net.javacrumbs.shedlock.core.LockingTaskExecutor;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import org.flywaydb.core.Flyway;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
@@ -20,8 +20,8 @@ import java.util.stream.Stream;
 
 import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 @Slf4j
 public class ShedlockTest {
@@ -30,7 +30,7 @@ public class ShedlockTest {
     private JdbcTemplate jdbcTemplate;
     private LockingTaskExecutor taskExecutor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         DataSource ds = createDataSource();
         jdbcTemplate = new JdbcTemplate(ds);
@@ -57,7 +57,7 @@ public class ShedlockTest {
         }, new LockConfiguration("shedlockTest1", lockTime, lockTime));
         List<Map<String, Object>> results = jdbcTemplate.queryForList("SELECT * FROM SHEDLOCK");
         int shedlockTestLocks = results.stream().map(m -> (String) m.get("name")).filter(isEqual("shedlockTest1")).collect(toList()).size();
-        assertThat(shedlockTestLocks, is(1));
+        assertThat(shedlockTestLocks).isEqualTo(1);
     }
 
     @Test
@@ -75,7 +75,7 @@ public class ShedlockTest {
                     }, lockConfig);
                 });
 
-        assertThat(listSomPopuleresIJobb.size(), is(1));
+        assertThat(listSomPopuleresIJobb.size()).isEqualTo(1);
     }
 
 }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/featureToggles/ByEnvironmentStrategyTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/featureToggles/ByEnvironmentStrategyTest.java
@@ -1,6 +1,6 @@
 package no.nav.arbeidsgiver.kontakt.oss.featureToggles;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/featureToggles/FeatureToggleControllerTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/featureToggles/FeatureToggleControllerTest.java
@@ -1,10 +1,10 @@
 package no.nav.arbeidsgiver.kontakt.oss.featureToggles;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import javax.servlet.http.HttpServletResponse;
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FeatureToggleControllerTest {
 
     @Mock
@@ -27,7 +27,7 @@ public class FeatureToggleControllerTest {
 
     private FeatureToggleController featureToggleController;
 
-    @Before
+    @BeforeEach
     public void setup() {
         featureToggleController = new FeatureToggleController(featureToggleService);
     }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/featureToggles/FeatureToggleServiceTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/featureToggles/FeatureToggleServiceTest.java
@@ -2,11 +2,11 @@ package no.nav.arbeidsgiver.kontakt.oss.featureToggles;
 
 import no.finn.unleash.Unleash;
 import no.finn.unleash.UnleashContext;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +17,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FeatureToggleServiceTest {
 
     @Mock
@@ -25,7 +25,7 @@ public class FeatureToggleServiceTest {
 
     private FeatureToggleService featureToggleService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         featureToggleService = new FeatureToggleService(unleash);
     }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/FylkesinndelingMedNavEnheterTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/FylkesinndelingMedNavEnheterTest.java
@@ -1,7 +1,7 @@
 package no.nav.arbeidsgiver.kontakt.oss.fylkesinndelingMedNavEnheter;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/FylkesinndelingRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/FylkesinndelingRepositoryTest.java
@@ -1,11 +1,9 @@
 package no.nav.arbeidsgiver.kontakt.oss.fylkesinndelingMedNavEnheter;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -14,7 +12,6 @@ import static no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData.fraFylkesenhete
 import static no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData.fraKommuneNrTilNavEnhet;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {"mock.enabled=false"})
 public class FylkesinndelingRepositoryTest {

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/FylkesinndelingSchedulerTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/FylkesinndelingSchedulerTest.java
@@ -2,17 +2,17 @@ package no.nav.arbeidsgiver.kontakt.oss.fylkesinndelingMedNavEnheter;
 
 import net.javacrumbs.shedlock.core.LockConfiguration;
 import net.javacrumbs.shedlock.core.LockingTaskExecutor;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FylkesinndelingSchedulerTest {
 
     @Mock

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/FylkesinndelingServiceTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/FylkesinndelingServiceTest.java
@@ -6,11 +6,11 @@ import no.nav.arbeidsgiver.kontakt.oss.fylkesinndelingMedNavEnheter.integrasjon.
 import no.nav.arbeidsgiver.kontakt.oss.fylkesinndelingMedNavEnheter.integrasjon.NorgKlient;
 import no.nav.arbeidsgiver.kontakt.oss.fylkesinndelingMedNavEnheter.integrasjon.NorgOrganisering;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.Arrays;
@@ -19,9 +19,10 @@ import java.util.HashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FylkesinndelingServiceTest {
 
     @Mock
@@ -38,7 +39,7 @@ public class FylkesinndelingServiceTest {
 
     private FylkesinndelingService fylkesinndelingService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fylkesinndelingService = new FylkesinndelingService(norgKlient, kodeverkKlient, fylkesinndelingRepository, eventPublisher);
     }
@@ -121,10 +122,10 @@ public class FylkesinndelingServiceTest {
         }
     }
 
-    @Test(expected = KontaktskjemaException.class)
+    @Test
     public void oppdaterFylkesinndeling__skal_kaste_kontaktskjema_exception_videre() {
         when(fylkesinndelingService.hentListeOverAlleKommunerOgBydeler()).thenThrow(KontaktskjemaException.class);
-        fylkesinndelingService.oppdaterFylkesinndeling();
+        assertThrows(KontaktskjemaException.class, () ->fylkesinndelingService.oppdaterFylkesinndeling());
     }
 
 }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/FylkesinndelingServiceTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/FylkesinndelingServiceTest.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/integrasjon/KodeverkKlientTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/integrasjon/KodeverkKlientTest.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 
 import static no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData.lesFil;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/integrasjon/KodeverkKlientTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/integrasjon/KodeverkKlientTest.java
@@ -3,13 +3,13 @@ package no.nav.arbeidsgiver.kontakt.oss.fylkesinndelingMedNavEnheter.integrasjon
 import no.nav.arbeidsgiver.kontakt.oss.KontaktskjemaException;
 import no.nav.arbeidsgiver.kontakt.oss.fylkesinndelingMedNavEnheter.Kommune;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
 
@@ -17,10 +17,11 @@ import java.util.Arrays;
 
 import static no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData.lesFil;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class KodeverkKlientTest {
 
     @Mock
@@ -31,7 +32,7 @@ public class KodeverkKlientTest {
 
     private KodeverkKlient kodeverkKlient;
 
-    @Before
+    @BeforeEach
     public void setup() {
         kodeverkKlient = new KodeverkKlient(restTemplate, "kodeverkUrl");
     }
@@ -70,10 +71,10 @@ public class KodeverkKlientTest {
         assertThat(kodeverkKlient.hentKommuner()).isEmpty();
     }
 
-    @Test(expected = KontaktskjemaException.class)
+    @Test
     public void hentKommuner__skal_feile_hvis_respons_ikke_returnerer_gyldig_json() {
         mockKommuneRespons("ikke gyldig json");
-        kodeverkKlient.hentKommuner();
+        assertThrows(KontaktskjemaException.class, () -> kodeverkKlient.hentKommuner());
     }
 
     @Test
@@ -110,10 +111,10 @@ public class KodeverkKlientTest {
         assertThat(kodeverkKlient.hentBydeler()).isEmpty();
     }
 
-    @Test(expected = KontaktskjemaException.class)
+    @Test
     public void hentBydeler__skal_feile_hvis_respons_ikke_returnerer_gyldig_json() {
         mockBydelRespons("ikke gyldig json");
-        kodeverkKlient.hentBydeler();
+        assertThrows(KontaktskjemaException.class, () -> kodeverkKlient.hentBydeler());
     }
 
     private void mockKommuneRespons(String jsonResponse) {

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/integrasjon/NorgKlientTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/integrasjon/NorgKlientTest.java
@@ -3,13 +3,13 @@ package no.nav.arbeidsgiver.kontakt.oss.fylkesinndelingMedNavEnheter.integrasjon
 import no.nav.arbeidsgiver.kontakt.oss.KontaktskjemaException;
 import no.nav.arbeidsgiver.kontakt.oss.fylkesinndelingMedNavEnheter.NavEnhet;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
 
@@ -19,10 +19,11 @@ import java.util.List;
 
 import static no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData.lesFil;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NorgKlientTest {
 
     @Mock
@@ -33,7 +34,7 @@ public class NorgKlientTest {
 
     private NorgKlient norgKlient;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         norgKlient = new NorgKlient(restTemplate, "");
     }
@@ -51,18 +52,19 @@ public class NorgKlientTest {
     }
 
 
-    @Test(expected = KontaktskjemaException.class)
+    @Test
     public void hentOrganiseringFraNorg__skal_feile_hvis_respons_ikke_returnerer_ok() {
         ResponseEntity responseEntity = new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR);
         when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(), eq(String.class))).thenReturn(responseEntity);
-        norgKlient.hentOrganiseringFraNorg();
+        assertThrows(KontaktskjemaException.class, () -> norgKlient.hentOrganiseringFraNorg());
+        ;
     }
 
-    @Test(expected = KontaktskjemaException.class)
+    @Test
     public void hentOrganiseringFraNorg__skal_feile_hvis_respons_ikke_returnerer_gyldig_json() {
         ResponseEntity<String> responseEntity = new ResponseEntity<>("{ikke gyldig json}", HttpStatus.OK);
         when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(), eq(String.class))).thenReturn(responseEntity);
-        norgKlient.hentOrganiseringFraNorg();
+        assertThrows(KontaktskjemaException.class, () -> norgKlient.hentOrganiseringFraNorg());
     }
 
     @Test

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/integrasjon/NorgKlientTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/fylkesinndelingMedNavEnheter/integrasjon/NorgKlientTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import static no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData.lesFil;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/gsak/GsakOppgaveRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/gsak/GsakOppgaveRepositoryTest.java
@@ -1,6 +1,5 @@
 package no.nav.arbeidsgiver.kontakt.oss.gsak;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,8 +8,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDateTime;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @TestPropertySource(properties = {"mock.enabled=false"})
@@ -29,11 +27,11 @@ public class GsakOppgaveRepositoryTest {
         GsakOppgave lagretOppgave = repository.save(GsakOppgave.builder().kontaktskjemaId(2).status(GsakOppgave.OppgaveStatus.OK).gsakId(5).opprettet(LocalDateTime.now()).build());
 
         GsakOppgave uthentetOppgave = repository.findById(lagretOppgave.getId()).get();
-        assertThat(uthentetOppgave.getId(), greaterThan(0));
-        assertThat(uthentetOppgave.getKontaktskjemaId(), is(2));
-        assertThat(uthentetOppgave.getStatus(), Matchers.is(GsakOppgave.OppgaveStatus.OK));
-        assertThat(uthentetOppgave.getGsakId(), is(5));
-        assertThat(uthentetOppgave.getOpprettet(), not(nullValue()));
+        assertThat(uthentetOppgave.getId()).isGreaterThan(0);
+        assertThat(uthentetOppgave.getKontaktskjemaId()).isEqualTo(2);
+        assertThat(uthentetOppgave.getStatus()).isEqualTo(GsakOppgave.OppgaveStatus.OK);
+        assertThat(uthentetOppgave.getGsakId()).isEqualTo(5);
+        assertThat(uthentetOppgave.getOpprettet()).isNotNull();
     }
 
 }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/gsak/GsakOppgaveRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/gsak/GsakOppgaveRepositoryTest.java
@@ -1,20 +1,17 @@
 package no.nav.arbeidsgiver.kontakt.oss.gsak;
 
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDateTime;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {"mock.enabled=false"})
 public class GsakOppgaveRepositoryTest {
@@ -22,7 +19,7 @@ public class GsakOppgaveRepositoryTest {
     @Autowired
     private GsakOppgaveRepository repository;
 
-    @After
+    @AfterEach
     public void tearDown() {
         repository.deleteAll();
     }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/gsak/GsakOppgaveSchedulerTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/gsak/GsakOppgaveSchedulerTest.java
@@ -3,15 +3,15 @@ package no.nav.arbeidsgiver.kontakt.oss.gsak;
 import net.javacrumbs.shedlock.core.LockConfiguration;
 import net.javacrumbs.shedlock.core.LockingTaskExecutor;
 import no.nav.arbeidsgiver.kontakt.oss.KontaktskjemaRepository;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GsakOppgaveSchedulerTest {
 
     @Mock

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/gsak/GsakOppgaveServiceTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/gsak/GsakOppgaveServiceTest.java
@@ -2,7 +2,6 @@ package no.nav.arbeidsgiver.kontakt.oss.gsak;
 
 import no.bekk.bekkopen.org.OrganisasjonsnummerCalculator;
 import no.nav.arbeidsgiver.kontakt.oss.*;
-import no.nav.arbeidsgiver.kontakt.oss.events.FylkesinndelingOppdatert;
 import no.nav.arbeidsgiver.kontakt.oss.events.GsakOppgaveOpprettet;
 import no.nav.arbeidsgiver.kontakt.oss.events.GsakOppgaveSendt;
 import no.nav.arbeidsgiver.kontakt.oss.gsak.integrasjon.GsakKlient;
@@ -10,13 +9,13 @@ import no.nav.arbeidsgiver.kontakt.oss.gsak.integrasjon.GsakRequest;
 import no.nav.arbeidsgiver.kontakt.oss.navenhetsmapping.NavEnhetService;
 import no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.MDC;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -27,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GsakOppgaveServiceTest {
 
     @Mock
@@ -46,7 +45,7 @@ public class GsakOppgaveServiceTest {
     @Captor
     ArgumentCaptor<GsakRequest> gsakRequestArgumentCaptor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(dateProvider.now()).thenReturn(LocalDateTime.now());
 

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/gsak/integrasjon/GsakKlientTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/gsak/integrasjon/GsakKlientTest.java
@@ -17,7 +17,7 @@ import org.springframework.web.client.RestTemplate;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/metrics/MetricsListenersTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/metrics/MetricsListenersTest.java
@@ -5,12 +5,13 @@ import no.nav.arbeidsgiver.kontakt.oss.events.GsakOppgaveSendt;
 import no.nav.arbeidsgiver.kontakt.oss.gsak.GsakOppgave;
 import no.nav.arbeidsgiver.kontakt.oss.gsak.GsakOppgaveService;
 import no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+
+@ExtendWith(MockitoExtension.class)
 public class MetricsListenersTest {
 
     @Mock

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/SalesforceKlientTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/SalesforceKlientTest.java
@@ -1,10 +1,10 @@
 package no.nav.arbeidsgiver.kontakt.oss.salesforce;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -12,9 +12,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import static no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData.contactForm;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SalesforceKlientTest {
     private SalesforceKlient salesforceKlient;
 
@@ -24,7 +25,7 @@ public class SalesforceKlientTest {
     private final static String authUrl = "authUrl";
     private final static String apiUrl = "apiUrl";
 
-    @Before
+    @BeforeEach
     public void setUp() {
         salesforceKlient = new SalesforceKlient(
                 restTemplate, authUrl, apiUrl, "", "", "", ""
@@ -42,17 +43,17 @@ public class SalesforceKlientTest {
                 .exchange(eq(authUrl), eq(HttpMethod.POST), any(HttpEntity.class), eq(SalesforceToken.class));
     }
 
-    @Test(expected = SalesforceException.class)
+    @Test
     public void sendKontaktskjemaTilSalesforce__skal_kaste_exception_hvis_resultatet_ikke_gir_200() {
         mockAuthKall(new ResponseEntity<>(new SalesforceToken("token"), HttpStatus.OK));
         mockApiKall(new ResponseEntity(HttpStatus.NOT_FOUND));
-        salesforceKlient.sendContactFormTilSalesforce(contactForm());
+        assertThrows(SalesforceException.class, () -> salesforceKlient.sendContactFormTilSalesforce(contactForm()));
     }
 
-    @Test(expected = SalesforceException.class)
+    @Test
     public void hentSalesforceToken__skal_kaste_exception_hvis_resultatet_ikke_gir_200() {
         mockAuthKall(new ResponseEntity(HttpStatus.BAD_REQUEST));
-        salesforceKlient.hentSalesforceToken();
+        assertThrows(SalesforceException.class, () -> salesforceKlient.hentSalesforceToken());
     }
 
     private void mockApiKall(ResponseEntity response) {

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/SalesforceKlientTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/SalesforceKlientTest.java
@@ -12,7 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import static no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData.contactForm;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/SalesforceServiceTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/SalesforceServiceTest.java
@@ -2,21 +2,19 @@ package no.nav.arbeidsgiver.kontakt.oss.salesforce;
 
 import no.nav.arbeidsgiver.kontakt.oss.Kontaktskjema;
 import no.nav.arbeidsgiver.kontakt.oss.TemaType;
-import no.nav.arbeidsgiver.kontakt.oss.featureToggles.FeatureToggleService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 
-import static no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData.kontaktskjema;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SalesforceServiceTest {
 
     private SalesforceService salesforceService;
@@ -24,7 +22,7 @@ public class SalesforceServiceTest {
     @Mock
     private SalesforceKlient salesforceKlient;
 
-    @Before
+    @BeforeEach
     public void setup() {
         salesforceService = new SalesforceService(salesforceKlient);
     }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/utsending/KontaktskjemaUtsendingRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/utsending/KontaktskjemaUtsendingRepositoryTest.java
@@ -1,17 +1,14 @@
 package no.nav.arbeidsgiver.kontakt.oss.salesforce.utsending;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static java.time.LocalDateTime.now;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {"mock.enabled=false"})
 public class KontaktskjemaUtsendingRepositoryTest {
@@ -19,11 +16,10 @@ public class KontaktskjemaUtsendingRepositoryTest {
     @Autowired
     private KontaktskjemaUtsendingRepository kontaktskjemaUtsendingRepository;
 
-    @After
+    @AfterEach
     public void tearDown() {
         kontaktskjemaUtsendingRepository.deleteAll();
     }
-
 
     @Test
     public void skalHenteBasertPåKontaktskjemaId() {

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/utsending/KontaktskjemaUtsendingRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/utsending/KontaktskjemaUtsendingRepositoryTest.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 import static java.time.LocalDateTime.now;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @TestPropertySource(properties = {"mock.enabled=false"})
@@ -26,7 +26,7 @@ public class KontaktskjemaUtsendingRepositoryTest {
         kontaktskjemaUtsendingRepository.save(KontaktskjemaUtsending.klarTilUtsending(123, now()));
 
         KontaktskjemaUtsending kontaktskjemaUtsending = kontaktskjemaUtsendingRepository.hentKontakskjemaUtsending(123);
-        assertNotNull(kontaktskjemaUtsending);
+        assertThat(kontaktskjemaUtsending).isNotNull();
     }
 
 }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/utsending/KontaktskjemaUtsendingSchedulerTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/utsending/KontaktskjemaUtsendingSchedulerTest.java
@@ -3,15 +3,15 @@ package no.nav.arbeidsgiver.kontakt.oss.salesforce.utsending;
 import net.javacrumbs.shedlock.core.LockConfiguration;
 import net.javacrumbs.shedlock.core.LockingTaskExecutor;
 import no.nav.arbeidsgiver.kontakt.oss.KontaktskjemaRepository;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class KontaktskjemaUtsendingSchedulerTest {
 
     @Mock

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/utsending/KontaktskjemaUtsendingServiceTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/utsending/KontaktskjemaUtsendingServiceTest.java
@@ -4,16 +4,14 @@ import no.nav.arbeidsgiver.kontakt.oss.Kontaktskjema;
 import no.nav.arbeidsgiver.kontakt.oss.KontaktskjemaRepository;
 import no.nav.arbeidsgiver.kontakt.oss.salesforce.SalesforceException;
 import no.nav.arbeidsgiver.kontakt.oss.salesforce.SalesforceService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static java.time.LocalDateTime.now;
 import static no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData.kontaktskjemaBuilder;
@@ -21,7 +19,6 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {"mock.enabled=false"})
 public class KontaktskjemaUtsendingServiceTest {
@@ -39,12 +36,12 @@ public class KontaktskjemaUtsendingServiceTest {
     private KontaktskjemaUtsendingService kontaktskjemaUtsendingService;
 
 
-    @Before
+    @BeforeEach
     public void setUp() {
         cleanUpDb();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         cleanUpDb();
     }

--- a/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/utsending/KontaktskjemaUtsendingServiceTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/kontakt/oss/salesforce/utsending/KontaktskjemaUtsendingServiceTest.java
@@ -15,7 +15,8 @@ import org.springframework.test.context.TestPropertySource;
 
 import static java.time.LocalDateTime.now;
 import static no.nav.arbeidsgiver.kontakt.oss.testUtils.TestData.kontaktskjemaBuilder;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
 
@@ -55,7 +56,7 @@ public class KontaktskjemaUtsendingServiceTest {
         kontaktskjemaUtsendingService.sendSkjemaTilSalesForce(kontaktskjema);
 
         KontaktskjemaUtsending kontaktskjemaUtsending = kontaktskjemaUtsendingRepository.findAll().iterator().next();
-        assertTrue(kontaktskjemaUtsending.erSent());
+        assertThat(kontaktskjemaUtsending.erSent()).isTrue();
     }
 
     @Test
@@ -68,18 +69,20 @@ public class KontaktskjemaUtsendingServiceTest {
         sjekkSkjemaErLagretOgKlartTilUtsending(kontaktskjema.getId());
 
         try {
-            kontaktskjemaUtsendingService.sendSkjemaTilSalesForce(kontaktskjema);
-            fail("SalesforceException var forventet her");
+            assertThrows(
+                    SalesforceException.class,
+                    () -> kontaktskjemaUtsendingService.sendSkjemaTilSalesForce(kontaktskjema)
+            );
         } catch (SalesforceException e) { /* Suksess */ }
 
         KontaktskjemaUtsending kontaktskjemaUtsending = kontaktskjemaUtsendingRepository.findAll().iterator().next();
-        assertFalse(kontaktskjemaUtsending.erSent());
+        assertThat(kontaktskjemaUtsending.erSent()).isFalse();
     }
 
 
     private void sjekkSkjemaErLagretOgKlartTilUtsending(Integer kontaktskjemaId) {
         KontaktskjemaUtsending kontaktskjemaUtsendingBeforeSending = kontaktskjemaUtsendingRepository.hentKontakskjemaUtsending(kontaktskjemaId);
-        assertFalse(kontaktskjemaUtsendingBeforeSending.erSent());
+        assertThat(kontaktskjemaUtsendingBeforeSending.erSent()).isFalse();
     }
 
     private Kontaktskjema opprettOgHentKontaktskjema() {


### PR DESCRIPTION
Spring 2.4.0 dropper støtte for JUnit Vintage. Kunne installert Vintage i appen, men jeg tok heller migreringsjobben til JUnit 5.