### PR TITLE
TAG-1574: tillatt spørsmålstegn som del av LATIN i validering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/upgrade-dependencies-januar-2021'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/TAG-1574'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.2</version>
         <relativePath/>
     </parent>
 
@@ -36,6 +36,28 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <version>1.3-groovy-2.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-spring</artifactId>
+            <version>1.3-groovy-2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -152,6 +174,18 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.7.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compileTests</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/no/nav/arbeidsgiver/kontakt/oss/KontaktskjemaService.java
+++ b/src/main/java/no/nav/arbeidsgiver/kontakt/oss/KontaktskjemaService.java
@@ -24,7 +24,8 @@ public class KontaktskjemaService {
     private final DateProvider dateProvider;
     private final NavEnhetService navEnhetService;
 
-    private final static String LATIN = "a-zA-Z \\-–'._)(/";
+    @SuppressWarnings("RegExpRedundantEscape") // brukes i character class, må escapes
+    private final static String LATIN = "a-zA-Z ?\\-–'._)(/";
     private final static String SAMISK = "ÁáČčĐđŊŋŠšŦŧŽž";
     private final static String NORSK = "æøåÆØÅ";
 

--- a/src/test/groovy/no/nav/arbeidsgiver/kontakt/oss/KontaktskjemaControllerSpockTest.groovy
+++ b/src/test/groovy/no/nav/arbeidsgiver/kontakt/oss/KontaktskjemaControllerSpockTest.groovy
@@ -1,0 +1,66 @@
+package no.nav.arbeidsgiver.kontakt.oss
+
+import no.nav.arbeidsgiver.kontakt.oss.navenhetsmapping.NavEnhetService
+import no.nav.arbeidsgiver.kontakt.oss.salesforce.utsending.KontaktskjemaUtsendingRepository
+import org.spockframework.spring.SpringBean
+import org.spockframework.spring.StubBeans
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import spock.lang.Specification
+
+import java.time.LocalDate
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@StubBeans([
+        KontaktskjemaUtsendingRepository,
+        ApplicationEventPublisher,
+        NavEnhetService,
+])
+@WebMvcTest(
+        controllers = [KontaktskjemaController, KontaktskjemaService, DateProvider],
+        properties = [
+                "kontaktskjema.max-requests-per-10-min=200"
+        ]
+)
+class KontaktskjemaControllerSpockTest extends Specification {
+
+    @Autowired
+    MockMvc mockMvc
+
+    @SpringBean
+    KontaktskjemaRepository kontaktskjemaRepository = Mock()
+
+    def "skal sende skjema tross rare tegn i kommunenavn"() {
+        given:
+        _ * kontaktskjemaRepository.findAllNewerThan(_) >> []
+        _ * kontaktskjemaRepository.toString()
+        when:
+        def result = mockMvc.perform(
+                post("/meldInteresse")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content($/{
+                    "fylkesenhetsnr": "42",
+                    "kommune": "Porsanger – Porsá?gu – Porsanki", 
+                    "kommunenr": "42", 
+                    "bedriftsnavn": "lol", 
+                    "orgnr": "889640782", 
+                    "fornavn": "lol", 
+                    "etternavn": "lol", 
+                    "epost": "lol@lol.no",
+                    "telefonnr": "42",
+                    "tema": "lol",
+                    "temaType": "REKRUTTERING",
+                    "harSnakketMedAnsattrepresentant": true 
+                }/$)
+        )
+
+        then:
+        1 * kontaktskjemaRepository.save(_) >> Stub(Kontaktskjema)
+        result.andExpect(status().is2xxSuccessful())
+    }
+}


### PR DESCRIPTION
Vi vurderte slik at vi tillater å sende gjennom ? som en del av LATIN. Dette kan muligens skape problemer nedstrøms, dersom kommunenavn som inneholder rart tegn medfører noe breakage. f.eks dersom den benyttes som teknisk referanse et sted.
Vi anser det som lite sannsynlig.